### PR TITLE
Updates Py version in .travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: python
 python:
-  - "3.4"
+  - "3.6"
 
 # command to install dependencies
 install:


### PR DESCRIPTION
Resolves following build error-
```
ERROR: PyYAML requires Python '>=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*' but the running Python is 3.4.8
```